### PR TITLE
:bug: fix applying patch with multiple versions of the same package

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,8 +269,8 @@ pub fn run() -> anyhow::Result<()> {
                         .and_then(|s| s.to_str())
                         .ok_or(anyhow!("Patch file does not have a name"))?;
 
-                    if let Some((pkg_name, _version)) = filename.split_once('+') {
-                        let pkg_id = resolve.query(pkg_name)?;
+                    if let Some((pkg_name, version)) = filename.split_once('+') {
+                        let pkg_id = resolve.query(format!("{}@{}", pkg_name, version).as_str())?;
                         let pkg = pkg_set.get_one(pkg_id)?;
                         if !crates_to_patch.contains(&pkg) {
                             warn!(


### PR DESCRIPTION
Hi there, thank you for making this project!

This PR fixes an error that is being thrown when multiple versions of the same
packages is being used.

Example Cargo.toml:

```toml
[package]
name = "pkg_name"
version = "0.1.0"
edition = "2021"

[dependencies]
core-foundation = "0.9.4"
core-foundation2 = {version="0.10.0", package="core-foundation"}

[package.metadata.patch]
crates = [
  "core-foundation@0.9.4",
  "core-foundation@0.10.0",
]
```

Before this patch, it would show the following error:

```bash
ERROR: There are multiple `core-foundation` packages in your project, and the specification `core-foundation` is ambiguous.
Please re-run this command with one of the following specifications:
  core-foundation@0.9.4
  core-foundation@0.10.0
```
