### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "patch-crate"
 version = "0.1.12"
 authors = ["YISH <mokeyish@hotmail.com>"]
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 repository = "https://github.com/mokeyish/cargo-patch-crate"
@@ -26,10 +26,9 @@ path = "src/main.rs"
 # crates = ["clap", "fs_extra"]
 
 
-
 [dependencies]
 paris = { version = "1.5", features = ["macros"] }
 anyhow = "1"
-cargo = "0.82"
+cargo = "0.86"
 fs_extra = "1"
-clap = { version = "4.4.7", features = ["derive"]}
+clap = { version = "4.5.31", features = ["derive"] }


### PR DESCRIPTION
This currently doesn't work for crates on 2024 edition. Seems like updating dependencies fixes it.

```
The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.81.0).
Consider adding `cargo-features = ["edition2024"]` to the top of Cargo.toml (above the [package] table) to tell Cargo you are opting in to use this unstable feature.
See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```