### PR TITLE
fix(#12): remove `--allow-empty` flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,6 @@ mod git {
                 "--ignore-space-change",
                 "--ignore-whitespace",
                 "--whitespace=nowarn",
-                "--allow-empty",
                 &patch_file,
             ])
             .output()?;


### PR DESCRIPTION
As #12 details `git apply --allow-empty <PATCH>` is unsupported on older versions of git (specifically tested with Ubuntu 22.04 which is not EoL until 2027).

I believe empty patches should be an error: e.g. you update a patched crate and the patch is included in the source making it unnecessary. You could then remove the patch from your repo and save time by skipping `cargo patch-crate` in CI/locally.

If you disagree I would be willing to modify this patch to instead catch the error when `--allow-empty` is not supported (by looking at the exit code) and removing the flag then.