### PR TITLE
fix: build broken due to cargo 0.86.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,6 @@ path = "src/main.rs"
 [dependencies]
 paris = { version = "1.5", features = ["macros"] }
 anyhow = "1"
-cargo = "0.86"
+cargo = "0.87"
 fs_extra = "1"
 clap = { version = "4.5.31", features = ["derive"] }


### PR DESCRIPTION
For some reason `cargo-0.86.0` fails to build, upgrading to `cargo-0.87.0` fixes the issue.

CI should've caught this, do you want me to setup GH actions on the repo?