### PR TITLE
Omits external differs during creating a patch 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,7 +385,7 @@ mod git {
 
         let out = Command::new("git")
             .current_dir(repo_dir)
-            .args([OsStr::new("diff"), OsStr::new("--staged")])
+            .args([OsStr::new("diff"), OsStr::new("--staged"), OsStr::new("--no-ext-diff")])
             .output()?;
 
         if out.status.success() {


### PR DESCRIPTION
So far the patches have not been generated properly if an external differ was configured on the machine

This PR fixes the problem by passing `--no-ext-diff` parameter to `git diff` command